### PR TITLE
Fix rebalancing amount and end-of-month data

### DIFF
--- a/src/tiportfolio/portfolio/allocation/allocation.py
+++ b/src/tiportfolio/portfolio/allocation/allocation.py
@@ -195,20 +195,10 @@ class Allocation(ABC):
                     if target_ratio is None:
                         logger.warning(f"No target ratio found for strategy {strategy.name} at rebalance date {step}")
 
-                    # Find the most recent rebalance date <= previous_step
-                    if previous_step:
-                        previous_rebalance_dates = [d for d in all_rebalance_dates if d <= previous_step]
-                        if previous_rebalance_dates:
-                            most_recent_rebalance = max(previous_rebalance_dates)
-                            previous_ratio = self.strategy_ratio_map.get((most_recent_rebalance, strategy.name), 0.0)
-                        else:
-                            previous_ratio = 0.0
-                    else:
-                        previous_ratio = 0.0
-                    ratio_diff = target_ratio - previous_ratio
-
-                    # amount to trade
-                    trade_amount = ratio_diff * previous_total_value
+                   # FIX: Calculate trade amount based on actual drift, not just ratio difference
+                    current_strategy_value = previous_quantity * stock_price
+                    target_strategy_value = target_ratio * previous_total_value
+                    trade_amount = target_strategy_value - current_strategy_value
 
                     # Calculate fees
                     commission_rate = self.config.get('commission', 0.0)

--- a/src/tiportfolio/portfolio/allocation/frequency_based_allocation.py
+++ b/src/tiportfolio/portfolio/allocation/frequency_based_allocation.py
@@ -227,12 +227,21 @@ class FrequencyBasedAllocation(Allocation, ABC):
                 return market_open.date() == dt.date() and matches_time(dt)
             except ValueError:
                 return False
+        # Fix: Correction for situations where no data is available at the end of the month
         elif self.rebalance_frequency == RebalanceFrequency.end_of_month:
-            # approximate by calendar month end
-            first_next_month = (dt.replace(day=28) + timedelta(days=4)).replace(day=1)
-            day_in_end = first_next_month - timedelta(days=1)
-            # use calendar month end check (may differ from last trading day)
-            return dt.date() == day_in_end.date() and matches_time(dt)
+            # Find the position of the current date in the data table.
+            try:
+                current_idx = self.all_steps.get_loc(current_step)
+            except KeyError:
+                return False            
+            # If this is the last piece of data, treat it as a rebalancing process.
+            if current_idx == len(self.all_steps) - 1:
+                return matches_time(current_step)                
+            # Look Ahead: Find the next date
+            next_step = self.all_steps[current_idx + 1]            
+            # If the month is different, it means today is the last trading day of this month.
+            is_last_trading_day = current_step.month != next_step.month            
+            return is_last_trading_day and matches_time(current_step)
         elif self.rebalance_frequency == RebalanceFrequency.start_of_quarter:
             # Use pre-computed dates for fast lookup; fall back to computing
             # next market open from the 1st of the quarter month.

--- a/src/tiportfolio/utils/init_tz.py
+++ b/src/tiportfolio/utils/init_tz.py
@@ -5,8 +5,13 @@ import time
 def init_tz(default_tz: str = 'America/New_York') -> None:
     """Initialize the timezone to America/Los_Angeles."""
     os.environ['TZ'] = default_tz
-    time.tzset()
-
+    
+    # Compatible with Windows systems
+    try:
+        time.tzset()
+    except AttributeError:
+        # On Windows systems, the time module does not have the tzset() function.
+        pass
 
 if __name__ == "__main__":
     init_tz()


### PR DESCRIPTION
- Rebalancing amount: Fixes the issue where the rebalancing strategy was not executed after the second month.
- End-of-month data: Fixed the issue where no data was displayed if the market was not open on the last day of the month.
- tzset() function compatible with Windows systems